### PR TITLE
fix(peer-dependency): angular common/core versions were not bumped to 13

### DIFF
--- a/projects/ngx-favicon/package.json
+++ b/projects/ngx-favicon/package.json
@@ -2,7 +2,7 @@
   "name": "ngx-favicon",
   "version": "0.0.1",
   "peerDependencies": {
-    "@angular/common": "11.1.0",
-    "@angular/core": "11.1.0"
+    "@angular/common": "^13.0.0",
+    "@angular/core": "^13.0.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/cloudnc/ngx-favicon/issues/41